### PR TITLE
Fixes #28

### DIFF
--- a/plm/models/product_template.py
+++ b/plm/models/product_template.py
@@ -148,7 +148,7 @@ class ProductTemplateExtension(models.Model):
                 'view_type': 'form',
                 'view_mode': 'tree,form',
                 'type': 'ir.actions.act_window',
-                'domain': [('id', 'in', self.getAllVersionTemplate.ids)],
+                'domain': [('id', 'in', self.getAllVersionTemplate().ids)],
                 'context': {}}
 
     @api.model


### PR DESCRIPTION
- Calls `getAllVersionTemplate` instead of referencing it

issue #28 