### PR TITLE
document: fix regression and remove duplicate fields

### DIFF
--- a/plm/views/ir_attachment_view.xml
+++ b/plm/views/ir_attachment_view.xml
@@ -69,6 +69,10 @@
                </div>
             </xpath>
 
+            <xpath expr="//sheet/group/group[1]" position="replace">
+                <br/>
+            </xpath>
+
             <xpath expr="//div[@name='creation_div']" position="after">
                 <label for="write_uid" string="Modification"/>
                   <div name="modification_div">
@@ -89,14 +93,16 @@
             <xpath expr="//sheet/group[last()]" position="after">
                     <group name="doc_data">
                         <group name="main_doc_info">
-                            <strong>
-                                <field name="name" select="1"
-                                       attrs="{'readonly':[('state','in',['released','obsoleted'])]}"/>
-                            </strong>
-                            
-                            <strong>
+                            <group string="Created and Modified" name="doc_user">
+                                <field name="create_uid"  readonly="1"/>
+                                <field name="create_date" readonly="1"/>
+                                <field name="write_uid"   readonly="1"/>
+                                <field name="write_date"  readonly="1"/>
+                                <field name="attachment_release_user"   readonly="1"/>
+                                <field name="attachment_release_date"  readonly="1"/>
                                 <field name="revisionid" readonly="True"/>
-                            </strong>
+                                <field name="is_plm" group="base.group_no_one"/>
+                            </group>
                         </group>
                         <group name="doc_preview">
                             <field
@@ -150,7 +156,10 @@
                             <label for="description" class="oe_edit_only"/>
                             <field colspan="4" name="description" nolabel="1"
                                    attrs="{'readonly':[('state','in',['released','obsoleted'])]}"/>
-                            <label for="desc_modify" class="oe_edit_only"/>
+                            <br/>
+                            <br/>
+                            <label for="desc_modify" class="oe_edit_only"
+                                    attrs="{'invisible': [('revisionid', '=', 0)]}"/>
                             <field colspan="4" name="desc_modify" nolabel="1"
                                    attrs="{'readonly':[('state','in',['released','obsoleted'])], 'invisible': [('revisionid', '=', 0)]}"/>
                         </page>


### PR DESCRIPTION
I removed some additional duplicate fields; in particular, I removed the file field of the parent to prohibit the modification of release documents.

This part has no effect:
`
            <xpath expr="//div[@name='creation_div']" position="after">
                <label for="write_uid" string="Modification"/>
                  <div name="modification_div">
                     <field name="write_uid" readonly="1" class="oe_inline"/> on
                     <field name="write_date" readonly="1" class="oe_inline"/>
                 </div>
                 <field name="attachment_release_user"   readonly="1"/>
                 <field name="attachment_release_date"  readonly="1"/>
                 <field name="is_plm" group="base.group_no_one"/>
            </xpath>
`


creation_div is not present anywhere. I rolled back to the previous group for the document info. If we fix this part I can remove it before merging.

Please Matteo, tell me how to rearrange the commit before merging in 12.0

Alessio