### PR TITLE
[FIX] plm: fix mrp.bom.line BOM referance search

### DIFF
--- a/plm/models/mrp_bom_line.py
+++ b/plm/models/mrp_bom_line.py
@@ -50,12 +50,12 @@ class MrpBomLineExtension(models.Model):
         """
         bom_obj = self.env['mrp.bom']
         for bom_line in self:
-            for bom_id in self.search(
+            for bom_id in bom_obj.search(
                     [('product_id', '=', bom_line.product_id.id),
                      ('product_tmpl_id', '=', bom_line.product_id.product_tmpl_id.id),
                      ('type', '=', bom_line.type)]
             ):
-                child_bom = bom_obj.browse(bom_id)
+                child_bom = bom_obj.browse(bom_id.id)
                 for child_bom_line in child_bom.bom_line_ids:
                     child_bom_line._get_child_bom_lines()
                 self.child_line_ids = [x.id for x in child_bom.bom_line_ids]


### PR DESCRIPTION
Searching on self makes no sense as we are looking for a bom not a bom
line.
Also browsing a record is wrong, should be an id.