### PR TITLE
[#25112] requirements.txt : Removed the unknown package version cadquery2 from the requirements.txt file.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 ezdxf
 matplotlib
-cadquery2
 numpy-stl


### PR DESCRIPTION
[FIX] [#25112] requirements.txt : Removed the unknown package version cadquery2 from the requirements.txt file.

Getting package "cadquery2" error from the odooplm.
https://github.com/OmniaGit/odooplm/blob/15.0/requirements.txt#L3

ERROR: Could not find a version that satisfies the requirement cadquery2 (from versions: none)
ERROR: No matching distribution found for cadquery2
