### PR TITLE
fix issue when duplicating boms (partial backport from 15.0)

### DIFF
--- a/plm/__manifest__.py
+++ b/plm/__manifest__.py
@@ -20,7 +20,7 @@
 ##############################################################################
 {
     "name": "Product Lifecycle Management",
-    "version": "14.0.6",
+    "version": "14.0.7",
     "author": "OmniaSolutions",
     "website": "https://github.com/OmniaGit/odooplm",
     "category": "Manufacturing/Product Lifecycle Management",


### PR DESCRIPTION
added this fragment in copy method:

`                if not bom_line.product_id.product_tmpl_id.engineering_code:
                    bom_line.sudo().write({'state': 'draft',
                                           'source_id': False,})
                    continue`