### PR TITLE
[18.0] fix warning on dependencies

### DIFF
--- a/plm/models/product_template.py
+++ b/plm/models/product_template.py
@@ -74,7 +74,8 @@ class ProductTemplate(models.Model):
                                          )
     kit_bom = fields.Boolean(_('KIT Bom Type'))
 
-    linkeddocuments = fields.Many2many(related="product_variant_id.linkeddocuments")
+    linkeddocuments = fields.Many2many(related="product_variant_id.linkeddocuments",
+                                       depends=["product_variant_ids.linkeddocuments"])
 
     def action_open_linked_field(self, related_field):
         product_id = self.env['product.product'].browse(self.id)


### PR DESCRIPTION
Fixes the following warning:
UserWarning: Field 'product.template.product_variant_id' in dependency of product.template.linkeddocuments should be searchable. This is necessary to determine which records to recompute when product.product.linkeddocuments is modified. You should either make the field searchable, or simplify the field dependency.

product.template.product_variant_id is a non-stored computed field, so it can't be used as an (implict) dependency in a related field.

product.template.product_variant_ids OTOH can be used as dependency.